### PR TITLE
Implement domain oriented user creation with Swagger

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-# nutritionApp
+# Nutrition App
+
+This API manages users, clinics and appointments for the nutrition application.
+
+## Running the project
+
+Use Maven to build and run the application:
+
+```bash
+./mvnw spring-boot:run
+```
+
+Swagger UI is available once the application is running at `http://localhost:8080/swagger-ui.html`.

--- a/pom.xml
+++ b/pom.xml
@@ -95,11 +95,16 @@
 			<groupId>com.fasterxml.jackson.datatype</groupId>
 			<artifactId>jackson-datatype-jsr310</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-validation</artifactId>
-		</dependency>
-	</dependencies>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-validation</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.springdoc</groupId>
+                        <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+                        <version>2.5.0</version>
+                </dependency>
+        </dependencies>
 	<dependencyManagement>
 		<dependencies>
 			<dependency>

--- a/src/main/java/com/nutrition/mx/config/OpenApiConfig.java
+++ b/src/main/java/com/nutrition/mx/config/OpenApiConfig.java
@@ -1,0 +1,15 @@
+package com.nutrition.mx.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info().title("Nutrition API").version("1.0"));
+    }
+}

--- a/src/main/java/com/nutrition/mx/controller/AdminController.java
+++ b/src/main/java/com/nutrition/mx/controller/AdminController.java
@@ -1,0 +1,26 @@
+package com.nutrition.mx.controller;
+
+import com.nutrition.mx.dto.request.CreateUserRequest;
+import com.nutrition.mx.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/admins")
+@RequiredArgsConstructor
+public class AdminController {
+    private final UserService userService;
+
+    @PostMapping
+    public ResponseEntity<?> createAdmin(@Valid @RequestBody CreateUserRequest request, Authentication authentication){
+        return userService.createAdmin(request, authentication.getName());
+    }
+
+    @PostMapping("/super")
+    public ResponseEntity<?> createSuperAdmin(@Valid @RequestBody CreateUserRequest request, Authentication authentication){
+        return userService.createSuperAdmin(request, authentication.getName());
+    }
+}

--- a/src/main/java/com/nutrition/mx/controller/AuthController.java
+++ b/src/main/java/com/nutrition/mx/controller/AuthController.java
@@ -11,7 +11,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.nutrition.mx.dto.AuthRequest;
 import com.nutrition.mx.dto.AuthResponse;
-import com.nutrition.mx.dto.request.CreateUserRequest;
 import com.nutrition.mx.model.User;
 import com.nutrition.mx.repository.UserRepository;
 import com.nutrition.mx.security.JwtService;
@@ -38,10 +37,6 @@ public class AuthController {
 		return new AuthResponse(jwt);
 	}
 
-	@PostMapping("/superuser")
-	public ResponseEntity<?> createSuperUser(@RequestBody CreateUserRequest user) {
-		return userService.createSuperUser(user);
-	}
 
 	@PostMapping("/clinic-user")
 	public ResponseEntity<?> createUserForClinic(@RequestParam String clinicId, @RequestBody User user) {

--- a/src/main/java/com/nutrition/mx/security/SecurityConfig.java
+++ b/src/main/java/com/nutrition/mx/security/SecurityConfig.java
@@ -33,15 +33,18 @@ public class SecurityConfig {
 	        .csrf(csrf -> csrf.disable())
 	        .cors(Customizer.withDefaults())
 	        .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-	        .authorizeHttpRequests(auth -> auth
-	            .requestMatchers("/api/auth/**").permitAll()
-	            .requestMatchers(HttpMethod.POST, "/api/clinics/**")
-	                .hasAuthority(RoleName.SUPER_ADMIN.name())
-	            .requestMatchers(HttpMethod.POST, "/api/users/**")
-	                .hasAnyAuthority(
-	                    RoleName.SUPER_ADMIN.name(),
-	                    RoleName.CLINIC_ADMIN.name(),
-	                    RoleName.ESPECIALISTA.name()
+                .authorizeHttpRequests(auth -> auth
+                    .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
+                    .requestMatchers("/api/auth/**").permitAll()
+                    .requestMatchers(HttpMethod.POST, "/api/clinics/**")
+                        .hasAuthority(RoleName.SUPER_ADMIN.name())
+                    .requestMatchers(HttpMethod.POST, "/api/admins/**")
+                        .hasAuthority(RoleName.SUPER_ADMIN.name())
+                    .requestMatchers(HttpMethod.POST, "/api/users/**")
+                        .hasAnyAuthority(
+                            RoleName.SUPER_ADMIN.name(),
+                            RoleName.CLINIC_ADMIN.name(),
+                            RoleName.ESPECIALISTA.name()
 	                )
 	                .requestMatchers(HttpMethod.POST, "/api/citas/**")
 	                .hasAnyAuthority(

--- a/src/main/java/com/nutrition/mx/service/UserService.java
+++ b/src/main/java/com/nutrition/mx/service/UserService.java
@@ -1,7 +1,6 @@
 package com.nutrition.mx.service;
 
 import java.util.List;
-import java.util.Set;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -27,22 +26,32 @@ public class UserService {
 	private final PatientService patientService;
 	private final EspecialistaService especialistaService;
 
-	public ResponseEntity<?> createSuperUser(CreateUserRequest user) {
-		User newUser = User.builder().username(user.getUsername()).password(passwordEncoder.encode(user.getPassword()))
-				.fullName(user.getFullName()).email(user.getEmail()).roles(user.getRoles()).build();
+        public ResponseEntity<?> createSuperAdmin(CreateUserRequest request, String currentUsername) {
+                User currentUser = userRepository.findByUsername(currentUsername)
+                                .orElseThrow(() -> new UsernameNotFoundException("Usuario actual no encontrado"));
+                if (!currentUser.getRoles().contains(RoleName.SUPER_ADMIN)) {
+                        throw new AccessDeniedException("No tienes permiso para crear super administradores");
+                }
+                request.setRoles(List.of(RoleName.SUPER_ADMIN));
+                return createBasicUser(request);
+        }
 
-		User savedUser = userRepository.save(newUser);
-		return ResponseEntity.status(HttpStatus.CREATED).body(savedUser);
-	}
+        public ResponseEntity<?> createAdmin(CreateUserRequest request, String currentUsername) {
+                User currentUser = userRepository.findByUsername(currentUsername)
+                                .orElseThrow(() -> new UsernameNotFoundException("Usuario actual no encontrado"));
+                if (!currentUser.getRoles().contains(RoleName.SUPER_ADMIN)) {
+                        throw new AccessDeniedException("No tienes permiso para crear administradores");
+                }
+                request.setRoles(List.of(RoleName.CLINIC_ADMIN));
+                return createBasicUser(request);
+        }
 
 	public ResponseEntity<?> createUser(CreateUserRequest request, String currentUsername) {
 		User currentUser = userRepository.findByUsername(currentUsername)
 				.orElseThrow(() -> new UsernameNotFoundException("Usuario actual no encontrado"));
-		List<RoleName> currentUserRoles = currentUser.getRoles();
-		if (containsAdminRole(request.getRoles())
-				&& !hasAuthority(currentUserRoles, RoleName.SUPER_ADMIN, RoleName.CLINIC_ADMIN)) {
-			throw new AccessDeniedException("No tienes permiso para asignar estos roles");
-		}
+                if (containsAdminRole(request.getRoles())) {
+                        throw new AccessDeniedException("La creación de administradores se realiza en un endpoint dedicado");
+                }
 		
 		if(existUserEmail(request.getEmail())) {
 			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Ya existe un registro de usuario con ese email");
@@ -56,39 +65,45 @@ public class UserService {
 			return patientService.registrarPaciente(request, currentUsername);
 		}
 
-		if (request.getRoles().contains(RoleName.ESPECIALISTA)) {
-			return especialistaService.registrarEspecialista(request, currentUsername);
-		}
-		String newUserId = sequenceGeneratorService.generateSequence("users_sequence");
-		User newUser = User.builder().username(request.getUsername())
-				.password(passwordEncoder.encode(request.getPassword())).fullName(request.getFullName())
-				.email(request.getEmail()).clinicId(request.getClinicId()).roles(request.getRoles())
-				.especialistaInfo(null).pacienteProfile(null).userId(newUserId).build();
-		User savedUser = userRepository.save(newUser);
-		return ResponseEntity.status(HttpStatus.CREATED).body(savedUser);
+                if (request.getRoles().contains(RoleName.ESPECIALISTA)) {
+                        return especialistaService.registrarEspecialista(request, currentUsername);
+                }
+                return createBasicUser(request);
 
 	}
 
-	public User createUserInClinic(User user, String clinicId, List<RoleName> roles) {
-		user.setClinicId(clinicId);
-		user.setRoles(roles);
-		user.setPassword(passwordEncoder.encode(user.getPassword()));
-		return userRepository.save(user);
-	}
+        public User createUserInClinic(User user, String clinicId, List<RoleName> roles) {
+                user.setClinicId(clinicId);
+                user.setRoles(roles);
+                user.setPassword(passwordEncoder.encode(user.getPassword()));
+                return userRepository.save(user);
+        }
 
-	private boolean containsAdminRole(List<RoleName> roles) {
-		return roles.stream().anyMatch(
-				role -> role == RoleName.SUPER_ADMIN || role == RoleName.CLINIC_ADMIN || role == RoleName.ESPECIALISTA);
-	}
+        private ResponseEntity<User> createBasicUser(CreateUserRequest request) {
+                String newUserId = sequenceGeneratorService.generateSequence("users_sequence");
+                User newUser = User.builder()
+                                .username(request.getUsername())
+                                .password(passwordEncoder.encode(request.getPassword()))
+                                .fullName(request.getFullName())
+                                .email(request.getEmail())
+                                .clinicId(request.getClinicId())
+                                .roles(request.getRoles())
+                                .especialistaInfo(request.getEspecialistaInfo())
+                                .pacienteProfile(request.getPacienteProfile())
+                                .userId(newUserId)
+                                .build();
+                User saved = userRepository.save(newUser);
+                return ResponseEntity.status(HttpStatus.CREATED).body(saved);
+        }
 
-	private boolean hasAuthority(List<RoleName> roles, RoleName... allowedRoles) {
-		Set<RoleName> allowed = Set.of(allowedRoles);
-		return roles.stream().anyMatch(allowed::contains);
-	}
-	
-	private boolean existUserEmail (String emailUser) {
-		return userRepository.findByEmail(emailUser).isPresent();
-	}
+        private boolean containsAdminRole(List<RoleName> roles) {
+                return roles.stream().anyMatch(
+                                role -> role == RoleName.SUPER_ADMIN || role == RoleName.CLINIC_ADMIN);
+        }
+
+        private boolean existUserEmail (String emailUser) {
+                return userRepository.findByEmail(emailUser).isPresent();
+        }
 	
 	private boolean existeUserName (String userName) {
 		return userRepository.findByUsername(userName).isPresent();


### PR DESCRIPTION
## Summary
- add springdoc dependency and OpenAPI config
- add endpoints for admin and super-admin creation
- restrict admin creation to dedicated endpoints
- expose Swagger and update security rules
- update README with Swagger info

## Testing
- `mvnw test` *(fails: repository download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687273a54db0832b9970124abf7981fa